### PR TITLE
Make eslint not complain in vite config.

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,3 +1,4 @@
+/* eslint-env node */
 import { svelte }    from '@sveltejs/vite-plugin-svelte';
 import resolve       from '@rollup/plugin-node-resolve'; // This resolves NPM modules from node_modules.
 import preprocess    from 'svelte-preprocess';


### PR DESCRIPTION
Add a comment specifying node runtime to the vite.config.js to not have errors pop up. 

This does not add the node env to other files.